### PR TITLE
🔒️ [ci] Pin Gitleaks source revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             - name: "Install native lint tools"
               run: |
                   set -euo pipefail
-                  go install github.com/zricethezav/gitleaks/v8@v8.30.1
+                  go install github.com/zricethezav/gitleaks/v8@83d9cd684c87d95d656c1458ef04895a7f1cbd8e
                   echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
                   python -m pip install --user --disable-pip-version-check yamllint==1.38.0
                   echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -126,7 +126,7 @@ jobs:
             - name: "Install native lint tools"
               run: |
                   set -euo pipefail
-                  go install github.com/zricethezav/gitleaks/v8@v8.30.1
+                  go install github.com/zricethezav/gitleaks/v8@83d9cd684c87d95d656c1458ef04895a7f1cbd8e
                   echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
                   python -m pip install --user --disable-pip-version-check yamllint==1.38.0
                   echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"


### PR DESCRIPTION
## Summary

- replace the mutable Gitleaks v8.30.1 tag in CI and release verification with its immutable source commit
- keep the existing Gitleaks release and scan behavior while satisfying the supply-chain integrity requirement

## Validation

- GitHub tag object v8.30.1 resolves to 83d9cd684c87d95d656c1458ef04895a7f1cbd8e
- local go install from that exact commit completed successfully
- the resulting binary scanned the repository with the shared Gitleaks config and found no leaks
- npm run lint:actions
- Prettier workflow checks