### PR TITLE
🐛 Derive CLI version from package metadata

### DIFF
--- a/scripts/check-built-entrypoints.mjs
+++ b/scripts/check-built-entrypoints.mjs
@@ -4,11 +4,14 @@
  * Verify the runtime contracts of the built ESM and CommonJS entrypoints.
  */
 
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 const runtimeRequire = createRequire(import.meta.url);
 const esmModule = await import("../dist/chunky-lint.js");
 const cjsModule = runtimeRequire("../dist/chunky-lint.cjs");
+const packageMetadata = runtimeRequire("../package.json");
 const {
     ConsoleLogger: cjsConsoleLogger,
     ESLintChunker: cjsESLintChunker,
@@ -52,4 +55,27 @@ if (!Object.is(cjsModule, cjsESLintChunker)) {
     );
 }
 
-console.log("Built ESM and CommonJS entrypoint contracts are valid.");
+const packageVersion = packageMetadata["version"];
+
+if (typeof packageVersion !== "string" || packageVersion.trim().length === 0) {
+    throw new TypeError(
+        "Expected package.json to contain a non-empty string version."
+    );
+}
+
+const cliPath = fileURLToPath(
+        new URL("../dist/bin/eslint-chunker.js", import.meta.url)
+    ),
+    cliVersion = execFileSync(process.execPath, [cliPath, "--version"], {
+        encoding: "utf8",
+    }).trim();
+
+if (cliVersion !== packageVersion) {
+    throw new TypeError(
+        `Expected the built CLI version to equal package.json (${packageVersion}), received ${cliVersion}.`
+    );
+}
+
+console.log(
+    `Built ESM, CommonJS, and CLI entrypoint contracts are valid for v${packageVersion}.`
+);

--- a/src/bin/eslint-chunker.ts
+++ b/src/bin/eslint-chunker.ts
@@ -1,6 +1,7 @@
 import type { LiteralUnion } from "type-fest";
 
 import { Command } from "commander";
+import { createRequire } from "node:module";
 import {
     arrayJoin,
     isDefined,
@@ -54,6 +55,30 @@ const FIX_TYPES = [
     "suggestion",
 ] as const;
 const FIX_TYPE_SET = new Set<string>(FIX_TYPES);
+const runtimeRequire = createRequire(import.meta.url);
+
+const readPackageVersion = (): string => {
+    const packageMetadata: unknown = runtimeRequire("../../package.json");
+
+    if (typeof packageMetadata !== "object" || packageMetadata === null) {
+        throw new TypeError(
+            "Expected package.json to contain an object-valued root."
+        );
+    }
+
+    const packageVersion: unknown = Reflect.get(packageMetadata, "version");
+
+    if (
+        typeof packageVersion !== "string" ||
+        packageVersion.trim().length === 0
+    ) {
+        throw new TypeError(
+            "Expected package.json to contain a non-empty string version."
+        );
+    }
+
+    return packageVersion;
+};
 
 const isMaxWorkersKeyword = (value: MaxWorkersInput): value is "auto" | "off" =>
     value === "auto" || value === "off";
@@ -323,7 +348,7 @@ const program = new Command();
 program
     .name("eslint-chunker")
     .description("Auto-chunking ESLint runner that updates cache incrementally")
-    .version("1.0.0")
+    .version(readPackageVersion())
     .option("-c, --config <path>", "Path to ESLint config file")
     .option("-s, --size <number>", "Files per chunk", parseIntOption)
     .option("--cache-location <path>", "ESLint cache file location")


### PR DESCRIPTION
Summary: replace the hardcoded CLI version with the installed package metadata version; extend the built-entrypoint gate to execute the compiled CLI and require exact equality with package.json. Release evidence: the independently installed 1.8.0 artifact exposed all four aliases reporting 1.0.0. Validation: build, strict typecheck, targeted ESLint and Prettier, CLI Vitest, and full release:check with 116 tests, Publint, and ATTW all passed. Publication note: this PR does not move or republish v1.8.0; a corrective release requires separate explicit authorization because the authorized release dispatch has already been used.