### PR TITLE
♻️ [refactor] Resolve remaining Sonar findings

### DIFF
--- a/scripts/sync-node-version-files.mjs
+++ b/scripts/sync-node-version-files.mjs
@@ -118,7 +118,9 @@ const parseArguments = (argumentList) => {
     /** @type {string | null} */
     let explicitVersion = null;
 
-    for (let index = 0; index < argumentList.length; index += 1) {
+    let index = 0;
+
+    while (index < argumentList.length) {
         const argument = argumentList[index];
 
         if (typeof argument !== "string") {
@@ -135,17 +137,19 @@ const parseArguments = (argumentList) => {
 
         if (versionOverride !== null) {
             explicitVersion = versionOverride.explicitVersion;
-            index = versionOverride.nextIndex;
+            index = versionOverride.nextIndex + 1;
             continue;
         }
 
         if (argument === "--check") {
             checkOnly = true;
+            index += 1;
             continue;
         }
 
         if (argument === "--check-current") {
             checkCurrent = true;
+            index += 1;
             continue;
         }
 

--- a/src/chunky-lint.ts
+++ b/src/chunky-lint.ts
@@ -26,9 +26,10 @@ import type {
     ProgressCallback as ProgressCallbackType,
 } from "./types/chunky-lint-types.js";
 
-import { ESLintChunker } from "./lib/chunker.js";
-
-export { ESLintChunker } from "./lib/chunker.js";
+/**
+ * Default and named chunker exports.
+ */
+export { ESLintChunker as default, ESLintChunker } from "./lib/chunker.js";
 export { FileScanner } from "./lib/file-scanner.js";
 export { ConsoleLogger } from "./lib/logger.js";
 
@@ -61,8 +62,3 @@ export type Logger = LoggerType;
  * Progress callback signature.
  */
 export type ProgressCallback = ProgressCallbackType;
-
-/**
- * Default export for convenience.
- */
-export default ESLintChunker;


### PR DESCRIPTION
## Summary

- replace the variable-width `for` loop cursor in the Node-version argument parser with an explicit `while` cursor
- re-export `ESLintChunker` directly as both the named and default entrypoint export
- close the two remaining project-wide Sonar findings without changing public behavior

## Sonar findings

- `javascript:S2310` in `scripts/sync-node-version-files.mjs`
- `typescript:S7763` in `src/chunky-lint.ts`

## Validation

- `node scripts/sync-node-version-files.mjs --check`
- `node scripts/sync-node-version-files.mjs --check --version 26.3.0`
- `node scripts/sync-node-version-files.mjs --check --version=26.3.0`
- targeted ESLint and Prettier checks
- `npx vitest run src/test/index.test.ts` (9 tests)
- `npm run typecheck`
- `npm run build`
- `npm run release:check` (116 tests; non-mutating tracked-worktree invariant)